### PR TITLE
onnxconverter-common: Add 1.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,16 +12,18 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - wheel
+    - setuptools
   run:
     - packaging
-    - python >=3.6
+    - python
     - numpy
     - protobuf
     - onnx

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<35]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,9 +37,17 @@ test:
 about:
   home: https://github.com/microsoft/onnxconverter-common
   summary: Common utilities for ONNX converters
+  description: |
+    The onnxconverter-common package provides common functions and utilities for use in converters from various AI frameworks to ONNX. It also enables the different converters to work together to convert a model from mixed frameworks, like a scikit-learn pipeline embedding a xgboost model.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  dev_url: https://github.com/microsoft/onnxconverter-common
+  doc_url: https://github.com/microsoft/onnxconverter-common/blob/master/README.md
 
 extra:
   recipe-maintainers:
     - xhochy
+  skip-lints:
+    - missing_doc_source_url
+    - missing_license_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,3 @@ about:
 extra:
   recipe-maintainers:
     - xhochy
-  skip-lints:
-    - missing_doc_source_url
-    - missing_license_url


### PR DESCRIPTION
# onnxconverter-common v1.13.0
upstream: https://github.com/microsoft/onnxconverter-common/tree/v1.13.0
jira: https://anaconda.atlassian.net/browse/PKG-931
`requirements.txt`: https://github.com/microsoft/onnxconverter-common/blob/v1.13.0/requirements.txt
`setup.py`: https://github.com/microsoft/onnxconverter-common/blob/v1.13.0/setup.py

## Changes
- Fork from CF
- Remove noarch
- Update about section